### PR TITLE
Ignore referencing `aiohttp` at all

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,11 @@ sphinx:
   fail_on_warning: true
 formats: all
 
+submodules:
+  include: all
+  exclude: []
+  recursive: true
+
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -105,6 +105,7 @@
         "Sigstore",
         "sniffio",
         "sphinxcontrib",
+        "sphobjinv",
         "stestr",
         "Tabdeal",
         "testpypi",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,10 +28,28 @@ extensions = [
 ]
 
 nitpicky = True
+nitpick_ignore = [
+    ("py:class", "aiohttp.client.ClientSession"),  # Bypass referencing to aiohttp
+]
+# I tried a lot to also reference `aiohttp` but it didn't work
+# I tried creating my own `objects.inv` file which had the correct mappings, but it failed with >>>
+#       WARNING: failed to reach any of the inventories with the following issues:
+#       unknown or unsupported inventory version: ValueError('invalid inventory header: ')
+# I tried both manually creating and automatically with `sphobjinv`, but it didn't work.
+# The original link also fails with >>>
+#       WARNING: py:class reference target not found: aiohttp.client.ClientSession [ref.class]
+# I know the problem is with `autodoc` and `intersphinx` but i'm tired of trying to fix it.
+# If i could just tell it to map `aiohttp.client.ClientSession` to `aiohttp.ClientSession` somehow...
+# It took a lot of time from me, and i'm moving on.
+# Also it's not all the fault of `autodoc` and `intersphinx`, `aiohttp.client.ClientSession` actually DOES EXIST in the source code
+# but it's not documented and is an implementation detail and it shouldn't be referenced or imported that way.
+# # see: https://stackoverflow.com/questions/79448970/cannot-reference-aiohttp-classes-in-my-documentation
+
 
 napoleon_google_docstring = True
 
-autodoc_typehints = "description"
+autodoc_typehints = "both"
+autodoc_member_order = "alphabetical"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -20,7 +20,6 @@ base
     :members:
     :show-inheritance:
     :private-members:
-    :special-members:
 
 utils
 =====
@@ -29,4 +28,3 @@ utils
     :members:
     :show-inheritance:
     :private-members:
-    :special-members:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -18,9 +18,11 @@ base
 
 .. automodule:: unofficial_tabdeal_api.base
     :members:
+    :show-inheritance:
 
 utils
 =====
 
 .. automodule:: unofficial_tabdeal_api.utils
     :members:
+    :show-inheritance:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -20,6 +20,7 @@ base
     :members:
     :show-inheritance:
     :private-members:
+    :special-members:
 
 utils
 =====
@@ -28,3 +29,4 @@ utils
     :members:
     :show-inheritance:
     :private-members:
+    :special-members:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -19,6 +19,7 @@ base
 .. automodule:: unofficial_tabdeal_api.base
     :members:
     :show-inheritance:
+    :private-members:
 
 utils
 =====
@@ -26,3 +27,4 @@ utils
 .. automodule:: unofficial_tabdeal_api.utils
     :members:
     :show-inheritance:
+    :private-members:


### PR DESCRIPTION
I tried a lot also to reference `aiohttp` but it didn't work
I tried creating my own `objects.inv` file which had the correct mappings, but it failed with:

```
WARNING: failed to reach any of the inventories with the following issues:
unknown or unsupported inventory version: ValueError('invalid inventory header: ')
```
I tried manually creating and automatically with [sphobjinv](https://pypi.org/project/sphobjinv/), but it didn't work.
The original link also fails with:

```
WARNING: py:class reference target not found: aiohttp.client.ClientSession [ref.class]
```

I know the problem is with `autodoc` and `intersphinx` but I'm tired of trying to fix it.
If I could just tell it to map `aiohttp.client.ClientSession` to `aiohttp.ClientSession` somehow...
It took a lot of time from me, and I'm moving on.
Also, it's not all the fault of `autodoc` and `intersphinx`, `aiohttp.client.ClientSession` actually DOES EXIST in the source code
but it's not documented and is an implementation detail and it shouldn't be referenced or imported that way.

see: https://stackoverflow.com/questions/79448970/cannot-reference-aiohttp-classes-in-my-documentation