### PR TITLE
Dependabot now targets "test" branch for PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: daily
     assignees:
       - "MohsenHNSJ"
+    target-branch: "test"
 
   - package-ecosystem: pip
     directory: "/.github/workflows"
@@ -14,6 +15,7 @@ updates:
       interval: daily
     assignees:
       - "MohsenHNSJ"
+    target-branch: "test"
 
   - package-ecosystem: pip
     directory: "/docs"
@@ -21,6 +23,7 @@ updates:
       interval: daily
     assignees:
       - "MohsenHNSJ"
+    target-branch: "test"
 
   - package-ecosystem: pip
     directory: "/"
@@ -31,6 +34,7 @@ updates:
       - dependency-type: "all"
     assignees:
       - "MohsenHNSJ"
+    target-branch: "test"
 
   - package-ecosystem: docker
     directory: /.devcontainer
@@ -38,3 +42,4 @@ updates:
       interval: daily
     assignees:
       - "MohsenHNSJ"
+    target-branch: "test"


### PR DESCRIPTION
This will greatly improve dependency updating speed as no need to re-implement changes again manually.