### PR TITLE
Bug fix release

### DIFF
--- a/src/unofficial_tabdeal_api/base.py
+++ b/src/unofficial_tabdeal_api/base.py
@@ -43,6 +43,7 @@ class BaseClass:
         headers: dict[str, str] = {
             "user-hash": user_hash,
             "Authorization": authorization_key,
+            "Content-Type": "application/json",
         }
 
         self._client_session: ClientSession

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -29,6 +29,7 @@ TEST_USER_AUTH_KEY: str = "TEST_USER_AUTH_KEY"
 EXPECTED_SESSION_HEADERS: dict[str, str] = {
     "user-hash": TEST_USER_HASH,
     "Authorization": TEST_USER_AUTH_KEY,
+    "Content-Type": "application/json",
 }
 """Session header expected to receive"""
 INVALID_USER_HASH: str = "INVALID_USER_HASH"


### PR DESCRIPTION
This pull request includes a minor update to ensure the `Content-Type` header is consistently set to `application/json` in both the API client and its associated tests.

Header updates:

* [`src/unofficial_tabdeal_api/base.py`](diffhunk://#diff-97d2611bb50d705514311a4d0b320d3e3ddce11ba090872bb382db1662e03b00R46): Added `"Content-Type": "application/json"` to the headers dictionary in the `__init__` method to specify the content type for API requests.
* [`tests/test_constants.py`](diffhunk://#diff-85f35f24d7cc70f121d6ec00a1bcaa99af25d74a1621e0a610609fd1c40d7a3eR32): Updated the `EXPECTED_SESSION_HEADERS` dictionary to include `"Content-Type": "application/json"` for testing consistency with the API client headers.