### PR TITLE
Added model to init file to enable importing in production

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["poetry-core==2.1.3"]
 
 [project]
 name = "unofficial_tabdeal_api"
-version = "0.3.3" # Base version
+version = "0.3.4" # Base version
 description = "A Package to communicate with the Tabdeal platform"
 license = "MIT"
 readme = "README.rst"

--- a/src/unofficial_tabdeal_api/__init__.py
+++ b/src/unofficial_tabdeal_api/__init__.py
@@ -14,7 +14,7 @@ __license__ = "MIT"
 __copyright__ = "Copyright 2025-present MohsenHNSJ"
 __version__ = "0.3.4"
 
-from . import constants, enums, exceptions, utils
+from . import constants, enums, exceptions, models, utils
 from .authorization import AuthorizationClass
 from .base import BaseClass
 from .margin import MarginClass
@@ -32,5 +32,6 @@ __all__: list[str] = [
     "constants",
     "enums",
     "exceptions",
+    "models",
     "utils",
 ]

--- a/src/unofficial_tabdeal_api/__init__.py
+++ b/src/unofficial_tabdeal_api/__init__.py
@@ -12,7 +12,7 @@ __title__ = "unofficial-tabdeal-api"
 __author__ = "MohsenHNSJ"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025-present MohsenHNSJ"
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 from . import constants, enums, exceptions, utils
 from .authorization import AuthorizationClass


### PR DESCRIPTION
This pull request includes a version update for the `unofficial_tabdeal_api` package and adds a new module to the package's API.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10): Updated the package version from `0.3.3` to `0.3.4`.
* [`src/unofficial_tabdeal_api/__init__.py`](diffhunk://#diff-b791cb08304b563cc3e08c3f79618688b7d2cfb01efe611af6805a993e557904L15-R17): Updated the `__version__` attribute to reflect the new version `0.3.4`.

API enhancement:

* [`src/unofficial_tabdeal_api/__init__.py`](diffhunk://#diff-b791cb08304b563cc3e08c3f79618688b7d2cfb01efe611af6805a993e557904L15-R17): Added the `models` module to the package's imports and updated the `__all__` list to include `"models"`. [[1]](diffhunk://#diff-b791cb08304b563cc3e08c3f79618688b7d2cfb01efe611af6805a993e557904L15-R17) [[2]](diffhunk://#diff-b791cb08304b563cc3e08c3f79618688b7d2cfb01efe611af6805a993e557904R35)