### PR TITLE
Removed PDF version for read the docs documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,6 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - htmlzip
-  - pdf
 
 submodules:
   include: all

--- a/README.rst
+++ b/README.rst
@@ -65,9 +65,9 @@ There are also exclusive features that aren't available in the original API, suc
 🧰 Tech stack
 ~~~~~~~~~~~~~~
 
-* aiohttp_ 3.12.14
+* aiohttp_ 3.12.14 : Asynchronous HTTP client for Python, used for making API requests.
 
-* pydantic_ 2.9.2
+* pydantic_ 2.9.2 : Data validation using Python type annotations.
 
 🏁 Getting started
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["poetry-core==2.1.3"]
 
 [project]
 name = "unofficial_tabdeal_api"
-version = "0.3.6" # Base version
+version = "0.3.7" # Base version
 description = "A Package to communicate with the Tabdeal platform"
 license = "MIT"
 readme = "README.rst"

--- a/src/unofficial_tabdeal_api/__init__.py
+++ b/src/unofficial_tabdeal_api/__init__.py
@@ -12,7 +12,7 @@ __title__ = "unofficial-tabdeal-api"
 __author__ = "MohsenHNSJ"
 __license__ = "MIT"
 __copyright__ = "Copyright 2025-present MohsenHNSJ"
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 from . import constants, enums, exceptions, models, utils
 from .authorization import AuthorizationClass

--- a/src/unofficial_tabdeal_api/authorization.py
+++ b/src/unofficial_tabdeal_api/authorization.py
@@ -1,13 +1,9 @@
 """This module holds the AuthorizationClass."""
 
-import asyncio
-
 from unofficial_tabdeal_api.base import BaseClass
 from unofficial_tabdeal_api.constants import (
-    AUTH_KEY_INVALIDITY_THRESHOLD,
     GET_ACCOUNT_PREFERENCES_URI,
 )
-from unofficial_tabdeal_api.enums import DryRun
 from unofficial_tabdeal_api.exceptions import AuthorizationError
 
 
@@ -38,67 +34,3 @@ class AuthorizationClass(BaseClass):
         # So we return True
         self._logger.debug("Authorization key valid")
         return True
-
-    async def keep_authorization_key_alive(
-        self,
-        *,
-        _wait_time: int = 3000,
-        _dryrun: DryRun = DryRun.NO,
-    ) -> None:
-        """Keeps the Authorization key alive by periodically calling and using it.
-
-        This function is made to be used as an ongoing Task
-
-        Add to `asyncio.TaskGroup()` or similar ways
-
-        If the key happens to be invalid for AUTH_KEY_INVALIDITY_THRESHOLD times in a row,
-        the loop would stop.
-
-        Args:
-            _wait_time (int): Wait time in seconds. A value between 3000 and 3500 is preferable.
-                Defaults to 3000
-            _dryrun (DryRun): Run the loop only once for testing. Defaults to DryRun.NO
-        """
-        self._logger.debug(
-            "Keep authorization key alive started. Will check the key every [%s] seconds",
-            _wait_time,
-        )
-
-        consecutive_fails: int = 0
-
-        # This is a loop to use the Authorization key once every (wait_time), so it will not expire
-        # If the consecutive_fails is reached, the loop would exit and function should stop
-        while consecutive_fails < AUTH_KEY_INVALIDITY_THRESHOLD:
-            self._logger.debug("Waiting for [%s] seconds", _wait_time)
-            # First we wait, as we have already checked the authorization key at the start.
-            # This method's goal is to keep the key alive, not to check it.
-            await asyncio.sleep(_wait_time)
-
-            # Then we call the checker method
-            check_result: bool = await self.is_authorization_key_valid()
-
-            # Lastly, we log the result and loop again
-            if check_result:
-                self._logger.debug("Authorization key is still valid.")
-                # Reset the consecutive fails
-                consecutive_fails = 0
-            else:
-                self._logger.error(
-                    "Authorization key is INVALID or EXPIRED! Check result [%s]",
-                    check_result,
-                )
-                # Add one to consecutive fails
-                consecutive_fails += 1
-
-            # Check for dry running
-            if _dryrun is DryRun.YES:
-                # If dry run, break the loop
-                break
-
-        # After loop completion, if the consecutive fails are equal or above the set threshold,
-        # log an error
-        if consecutive_fails >= AUTH_KEY_INVALIDITY_THRESHOLD:
-            self._logger.error(
-                "Consecutive fails reached [%s] times!\nCheck Authorization key!",
-                AUTH_KEY_INVALIDITY_THRESHOLD,
-            )

--- a/src/unofficial_tabdeal_api/constants.py
+++ b/src/unofficial_tabdeal_api/constants.py
@@ -50,12 +50,6 @@ GENERIC_SERVER_CONFIRMATION_RESPONSE: str = '"درخواست مورد نظر ب�
 """Response when server receives the request, no guarantee of actually processing it!!!"""
 # endregion Server Responses
 
-# region Authorization
-AUTH_KEY_INVALIDITY_THRESHOLD: int = 5
-"""Number of consecutive fail responses to be tolerated,
-before giving up in keep_authorization_key_alive"""
-# endregion Authorization
-
 # region Margin
 GET_MARGIN_ASSET_DETAILS_URI: str = "/r/margin/margin-account-v2/"
 """URL for getting margin asset details"""

--- a/src/unofficial_tabdeal_api/enums.py
+++ b/src/unofficial_tabdeal_api/enums.py
@@ -3,15 +3,6 @@
 from enum import Enum
 
 
-class DryRun(Enum):
-    """Enum class to indicate whether to dry run or not."""
-
-    YES = 1
-    """Run as a Dry-run"""
-    NO = 2
-    """Don't run as a Dry-run"""
-
-
 class OrderState(Enum):
     """Enum class to indicate the state of order."""
 

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -14,7 +14,6 @@ from tests.test_constants import (
 )
 from tests.test_helper_functions import create_tabdeal_client, start_web_server
 from unofficial_tabdeal_api.authorization import AuthorizationClass
-from unofficial_tabdeal_api.enums import DryRun
 
 if TYPE_CHECKING:  # pragma: no cover
     from unofficial_tabdeal_api.tabdeal_client import TabdealClient
@@ -49,31 +48,3 @@ async def test_is_authorization_key_valid(aiohttp_server, caplog: pytest.LogCapt
         response = await invalid_authorization_object.is_authorization_key_valid()
         assert response is False
     assert "Authorization key invalid or expired!" in caplog.text
-
-
-async def test_keep_authorization_key_alive(
-    aiohttp_server,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Tests the keep_authorization_key_alive function."""
-    # Start web server
-    await start_web_server(aiohttp_server=aiohttp_server)
-
-    # Check correct function
-    test_keep_alive_object: TabdealClient = create_tabdeal_client()
-
-    with caplog.at_level(level=logging.DEBUG):
-        await test_keep_alive_object.keep_authorization_key_alive(_wait_time=1, _dryrun=DryRun.YES)
-        assert "Authorization key is still valid." in caplog.text
-
-    # Check error
-    error_test_keep_alive_object: AuthorizationClass = AuthorizationClass(
-        user_hash=INVALID_USER_HASH,
-        authorization_key=INVALID_USER_AUTH_KEY,
-        _is_test=True,
-    )
-
-    # Check error writing
-    with caplog.at_level(level=logging.ERROR):
-        await error_test_keep_alive_object.keep_authorization_key_alive(_wait_time=1)
-    assert "Consecutive fails reached" in caplog.text


### PR DESCRIPTION
This pull request includes several changes aimed at simplifying the codebase, improving clarity in documentation, and incrementing the package version. The most notable changes involve the removal of the `keep_authorization_key_alive` method and its associated logic, the deprecation of the `DryRun` enum, and updates to the version number and documentation.

### Codebase simplification:
* Removed the `keep_authorization_key_alive` method from `src/unofficial_tabdeal_api/authorization.py`, along with its associated logic, including the `AUTH_KEY_INVALIDITY_THRESHOLD` constant and references to `DryRun`. This simplifies the `AuthorizationClass` and eliminates unnecessary complexity. [[1]](diffhunk://#diff-47a82558727194e11818e3fb942af0214eb6b25b04c325a09defd806d4927f9eL41-L104) [[2]](diffhunk://#diff-47a82558727194e11818e3fb942af0214eb6b25b04c325a09defd806d4927f9eL3-L10) [[3]](diffhunk://#diff-2ff0e40a572d999aeeb7fba8d2ad74db63d7494214e15b2c424ace672d048ebcL6-L14) [[4]](diffhunk://#diff-5100a34fbf503a10c9501cdb3980c266d654052ed6b726bc2909cc5af692593cL17)
* Deleted the `DryRun` enum from `src/unofficial_tabdeal_api/enums.py` as it is no longer used.

### Version update:
* Incremented the package version from `0.3.6` to `0.3.7` in `pyproject.toml` and `src/unofficial_tabdeal_api/__init__.py` to reflect the changes made in this pull request. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10) [[2]](diffhunk://#diff-b791cb08304b563cc3e08c3f79618688b7d2cfb01efe611af6805a993e557904L15-R15)

### Documentation improvements:
* Enhanced the descriptions for dependencies in `README.rst` to clarify their purpose, such as detailing the use of `aiohttp` and `pydantic`.

### Configuration update:
* Removed the `pdf` format from the `.readthedocs.yml` configuration file, leaving only `htmlzip` as the supported format.