### PR TITLE
Fix critical bugs: Decimal import, README example, error handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ You can install *unofficial tabdeal api* via pip_ from PyPI_, requirements will 
     async def main():
 
         # Initialize a TabdealClient object
-        my_client: TabdealClient = TabdealClient(USER_HASH, USER_AUTHORIZATION_KEY)
+        my_client: TabdealClient = TabdealClient(user_hash=USER_HASH, authorization_key=USER_AUTHORIZATION_KEY)
 
         # Run your desired commands, remember to `await` the methods as all of them (except a few) are asynchronous
         bomeusdt_asset_id = await my_client.get_margin_asset_id("BOMEUSDT")

--- a/src/unofficial_tabdeal_api/base.py
+++ b/src/unofficial_tabdeal_api/base.py
@@ -156,7 +156,7 @@ class BaseClass:
                 status_code=server_status,
                 server_response=server_response,
             )
-        if server_status == constants.STATUS_UNAUTHORIZED:
+        elif server_status == constants.STATUS_UNAUTHORIZED:
             raise AuthorizationError(status_code=server_status)
         # Else, we raise a generic error
         self._logger.exception(

--- a/src/unofficial_tabdeal_api/exceptions.py
+++ b/src/unofficial_tabdeal_api/exceptions.py
@@ -211,8 +211,8 @@ class MarginOrderNotFoundInActiveOrdersError(Exception):
     def __init__(self) -> None:
         """Initializes the exception."""
         self.add_note(
-            "Order not found in active orders list!"
-            "Is order ID correct?"
+            "Order not found in active orders list! "
+            "Is order ID correct? "
             "Maybe order is completed and hit either SL or TP points",
         )
 

--- a/src/unofficial_tabdeal_api/models.py
+++ b/src/unofficial_tabdeal_api/models.py
@@ -274,8 +274,6 @@ class TransferFromMarginModel(BaseModel):
 class TransferToMarginModel(BaseModel):
     """Model for transferring USDT to margin asset."""
 
-    amount: int = 0
-    """A default value that is always 0 for no reason."""
     currency_symbol: str = "USDT"
     """Currency symbol for the transfer, defaults to 'USDT'."""
     pair_symbol: str

--- a/src/unofficial_tabdeal_api/tabdeal_client.py
+++ b/src/unofficial_tabdeal_api/tabdeal_client.py
@@ -1,6 +1,7 @@
 """This is the class of Tabdeal client."""
 
 import asyncio
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from unofficial_tabdeal_api.authorization import AuthorizationClass
@@ -13,8 +14,6 @@ from unofficial_tabdeal_api.utils import calculate_sl_tp_prices
 from unofficial_tabdeal_api.wallet import WalletClass
 
 if TYPE_CHECKING:  # pragma: no cover
-    from decimal import Decimal
-
     from unofficial_tabdeal_api.models import MarginOpenOrderModel
 
 


### PR DESCRIPTION
### Bugs Fixed

1. **Decimal imported under TYPE_CHECKING** — NameError at runtime when type annotations are evaluated. Moved to top-level import.

2. **README example uses positional args** — Constructor requires keyword-only args. Fixed example.

3. **if instead of elif in _check_response** — Fragile control flow that could produce double errors.

4. **Missing spaces in exception note** — String concatenation without spaces produced run-together message.

5. **Unused amount: int = 0 field** — Always serializes 0 in every API call for no reason.